### PR TITLE
Use repo level environment variables for UBUNTU_VERSION

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,8 +21,11 @@ on:
 jobs:
   setup:
     # default to dev when triggered by push
-    environment: ${{ inputs.target_env || 'dev' }}
     runs-on: ubuntu-latest
+
+    env:
+      target_env: ${{ github.event.inputs.target_env || 'dev' }}
+
     steps:
       - name: Determine Runner Type
         run: >
@@ -30,11 +33,13 @@ jobs:
           echo ${{ github }}
 
     outputs:
-      runner: ubuntu-${{ vars.UBUNTU_VERSION }}
+      target_env: ${{ env.target_env }}
+      runner: ubuntu-${{ vars[format('UBUNTU_VERSION_{0}', env.target_env)] }}
 
   deployment:
     needs: setup
     runs-on: ${{ needs.setup.outputs.runner }}
+    environment: ${{ needs.setup.outputs.target_env }}
     steps:
       - name: Checkout Repo Code
         uses: actions/checkout@v4
@@ -64,5 +69,3 @@ jobs:
 
       - name: Smoke Test
         run: echo "pretending to run smoke tests..."
-
-

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,12 +29,18 @@ jobs:
     steps:
       - name: Determine Runner Type
         run: >
+          echo "UBUNTU_VERSION_VAR_NAME=UBUNTU_VERSION_$(echo $target_env)" >> $GITHUB_ENV
           echo "determining runner type based on environment"
-          echo ${{ github }}
+          echo $UBUNTU_VERSION_VAR_NAME
+
+      - if: ${{ vars[UBUNTU_VERSION_VAR_NAME] == '' }}
+        run: |
+          echo "$UBUNTU_VERSION_VAR_NAME is not configured"
+          exit 1
 
     outputs:
       target_env: ${{ env.target_env }}
-      runner: ubuntu-${{ vars[format('UBUNTU_VERSION_{0}', env.target_env)] }}
+      runner: ubuntu-${{ vars[env.UBUNTU_VERSION_VAR_NAME] }}
 
   deployment:
     needs: setup

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,9 @@ jobs:
       - run: echo dolla $UBUNTU_VERSION_VAR_NAME
       - run: echo env ${{ env.UBUNTU_VERSION_VAR_NAME }}
 
-      - if: ${{ vars[env.UBUNTU_VERSION_VAR_NAME] == '' }}
+
+      - name: Verify UBUNTU_VERSION_{ENV} is set for ${{ env.target_env }}
+        if: ${{ vars[env.UBUNTU_VERSION_VAR_NAME] == '' }}
         run: |
           echo "$UBUNTU_VERSION_VAR_NAME is not configured"
           exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,10 +30,8 @@ jobs:
       - name: Determine Runner Type
         run: echo "UBUNTU_VERSION_VAR_NAME=UBUNTU_VERSION_$(echo $target_env)" >> $GITHUB_ENV
 
-      - run: echo $UBUNTU_VERSION_VAR_NAME
-
-      - run: echo env ${{ vars[env.UBUNTU_VERSION_VAR_NAME] }}
-      - run: echo vars ${{ vars[vars.UBUNTU_VERSION_VAR_NAME] }}
+      - run: echo dolla $UBUNTU_VERSION_VAR_NAME
+      - run: echo env ${{ env.UBUNTU_VERSION_VAR_NAME }}
 
       - if: ${{ vars[env.UBUNTU_VERSION_VAR_NAME] == '' }}
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,12 +28,14 @@ jobs:
 
     steps:
       - name: Determine Runner Type
-        run: >
-          echo "UBUNTU_VERSION_VAR_NAME=UBUNTU_VERSION_$(echo $target_env)" >> $GITHUB_ENV
-          echo "determining runner type based on environment"
-          echo $UBUNTU_VERSION_VAR_NAME
+        run: echo "UBUNTU_VERSION_VAR_NAME=UBUNTU_VERSION_$(echo $target_env)" >> $GITHUB_ENV
 
-      - if: ${{ vars[vars.UBUNTU_VERSION_VAR_NAME] == '' }}
+      - run: echo $UBUNTU_VERSION_VAR_NAME
+
+      - run: echo env ${{ vars[env.UBUNTU_VERSION_VAR_NAME] }}
+      - run: echo vars ${{ vars[vars.UBUNTU_VERSION_VAR_NAME] }}
+
+      - if: ${{ vars[env.UBUNTU_VERSION_VAR_NAME] == '' }}
         run: |
           echo "$UBUNTU_VERSION_VAR_NAME is not configured"
           exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
           echo "determining runner type based on environment"
           echo $UBUNTU_VERSION_VAR_NAME
 
-      - if: ${{ vars[UBUNTU_VERSION_VAR_NAME] == '' }}
+      - if: ${{ vars[vars.UBUNTU_VERSION_VAR_NAME] == '' }}
         run: |
           echo "$UBUNTU_VERSION_VAR_NAME is not configured"
           exit 1


### PR DESCRIPTION
This prevents the setup job from triggering an entry in deployment history

* UBUNTU_VERSION_DEV
* UBUNTU_VERSION_TEST
* UBUNTU_VERSION_PROD